### PR TITLE
Fix header row in CSV file

### DIFF
--- a/src/orgasm_control.c
+++ b/src/orgasm_control.c
@@ -447,8 +447,8 @@ void orgasm_control_start_recording() {
 
         fprintf(
             logger_state.logfile,
-            "millis,pressure,avg_pressure,arousal,motor_speed,sensitivity_threshold,"
-            "clench_pressure_threshold,clench_duration\n"
+            "millis,avg_pressure,arousal,motor_speed,sensitivity_threshold,"
+            "clench_pressure_threshold,clench_duration,orgasm_count\n"
         );
 
         ui_set_icon(UI_ICON_RECORD, RECORD_ICON_RECORDING);

--- a/src/orgasm_control.c
+++ b/src/orgasm_control.c
@@ -448,7 +448,7 @@ void orgasm_control_start_recording() {
         fprintf(
             logger_state.logfile,
             "millis,pressure,avg_pressure,arousal,motor_speed,sensitivity_threshold,"
-            "clench_pressure_threshold,clench_duration"
+            "clench_pressure_threshold,clench_duration\n"
         );
 
         ui_set_icon(UI_ICON_RECORD, RECORD_ICON_RECORDING);


### PR DESCRIPTION
As of the current release, there is no more line break between the header and the actual data in the csv file, aka it looks like this:

```csv
millis,pressure,avg_pressure,arousal,motor_speed,sensitivity_threshold,clench_pressure_threshold,clench_duration15,0,0,0,300,2755,0,1
68,0,0,0,300,2755,0,1
```

when it should look like this:

```csv
millis,pressure,avg_pressure,arousal,motor_speed,sensitivity_threshold,clench_pressure_threshold,clench_duration
15,0,0,0,300,2755,0,1
68,0,0,0,300,2755,0,1
```

This definitely worked in v0.6.4, so it must be a regression introduced by one of the later patches.

No idea if my commit is the correct solution, feel free to fix it some other way if needed.